### PR TITLE
51 funcionalidades de datos faltantes

### DIFF
--- a/lib/api/pivot_table/filter/create_filter.dart
+++ b/lib/api/pivot_table/filter/create_filter.dart
@@ -1,0 +1,15 @@
+import 'package:ut_report_generator/api/send_request.dart';
+import 'package:ut_report_generator/models/pivot_table/data_filter/self.dart';
+import 'package:ut_report_generator/models/pivot_table/pivot_table_level.dart';
+
+Future<DataFilter> createDataFilter({
+  required String report,
+  required String pivotTable,
+  required PivotTableLevel level,
+}) {
+  return sendRequest(
+    route: "pivot_table/filter/create",
+    callback: DataFilter.fromJson,
+    body: {"report": report, "pivot_table": pivotTable, "level": level.name},
+  );
+}

--- a/lib/api/pivot_table/filter/self.dart
+++ b/lib/api/pivot_table/filter/self.dart
@@ -1,4 +1,5 @@
 export 'package:ut_report_generator/api/pivot_table/filter/add_option.dart';
+export 'package:ut_report_generator/api/pivot_table/filter/create_filter.dart';
 export 'package:ut_report_generator/api/pivot_table/filter/remove_option.dart';
 export 'package:ut_report_generator/api/pivot_table/filter/switch_option.dart';
 export 'package:ut_report_generator/api/pivot_table/filter/toggle_selection_mode.dart';

--- a/lib/models/pivot_table/pivot_table_level.dart
+++ b/lib/models/pivot_table/pivot_table_level.dart
@@ -1,1 +1,16 @@
 enum PivotTableLevel { group, year, subject, professor, unit }
+
+String levelToSpanish(PivotTableLevel level) {
+  switch (level) {
+    case PivotTableLevel.group:
+      return "Grupo";
+    case PivotTableLevel.professor:
+      return "Profesor";
+    case PivotTableLevel.subject:
+      return "Materia";
+    case PivotTableLevel.unit:
+      return "Unidad";
+    case PivotTableLevel.year:
+      return "Año";
+  }
+}

--- a/lib/pages/home/report-editor/pivot_table_section/filter_selector.dart
+++ b/lib/pages/home/report-editor/pivot_table_section/filter_selector.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:ut_report_generator/models/pivot_table/pivot_table_level.dart';
+
+class FilterSelector extends StatefulWidget {
+  final List<PivotTableLevel> availableFilters;
+  final void Function(PivotTableLevel) onFilterSelected;
+  final String title;
+
+  const FilterSelector({
+    super.key,
+    required this.availableFilters,
+    required this.onFilterSelected,
+    required this.title,
+  });
+
+  @override
+  State<FilterSelector> createState() => _FilterSelectorState();
+}
+
+class _FilterSelectorState extends State<FilterSelector> {
+  late TextEditingController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = TextEditingController(text: widget.title);
+    controller.addListener(() {
+      if (controller.text != widget.title) {
+        controller.text = widget.title;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownMenu<String>(
+      controller: controller,
+      initialSelection: null,
+      trailingIcon: Icon(Icons.add),
+      inputDecorationTheme: InputDecorationTheme(border: InputBorder.none),
+      enableSearch: false,
+      dropdownMenuEntries:
+          widget.availableFilters
+              .map(
+                (filter) => DropdownMenuEntry(
+                  value: filter.name,
+                  label: levelToSpanish(filter),
+                ),
+              )
+              .toList(),
+      textStyle: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+      onSelected: (filter) {
+        if (filter != null) {
+          widget.onFilterSelected(PivotTableLevel.values.byName(filter));
+        }
+      },
+    );
+  }
+}

--- a/lib/pages/home/report-editor/pivot_table_section/pivot_metadata_pane.dart
+++ b/lib/pages/home/report-editor/pivot_table_section/pivot_metadata_pane.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 
 class PivotMetadataPane extends StatelessWidget {
@@ -22,7 +23,6 @@ class PivotMetadataPane extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         spacing: 16,
         children: [
-          Text("Algo de texto"),
           Column(
             spacing: 8,
             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -40,11 +40,27 @@ class PivotMetadataPane extends StatelessWidget {
                           File(path).path.split(Platform.pathSeparator).last;
                       return InputChip(
                         label: Text(filename),
+                        deleteButtonTooltipMessage: "Eliminar",
                         onDeleted: () async {
                           await onFileRemoved(path);
                         },
                       );
                     }).toList(),
+              ),
+              TextButton.icon(
+                onPressed: () async {
+                  FilePickerResult? result = await FilePicker.platform
+                      .pickFiles(
+                        allowMultiple: false,
+                        allowedExtensions: [".xls"],
+                      );
+                  if (result != null) {
+                    var file = result.files[0].path!;
+                    await onFileAdded(file);
+                  }
+                },
+                label: Text("Añadir archivo"),
+                icon: Icon(Icons.add),
               ),
             ],
           ),

--- a/lib/pages/home/report-editor/pivot_table_section/widget.dart
+++ b/lib/pages/home/report-editor/pivot_table_section/widget.dart
@@ -17,21 +17,6 @@ import 'package:ut_report_generator/utils/copy_with_added.dart';
 import 'package:ut_report_generator/utils/copy_with_replacement.dart';
 import 'package:ut_report_generator/utils/copy_without.dart';
 
-String levelToSpanish(PivotTableLevel level) {
-  switch (level) {
-    case PivotTableLevel.group:
-      return "Grupo";
-    case PivotTableLevel.professor:
-      return "Profesor";
-    case PivotTableLevel.subject:
-      return "Materia";
-    case PivotTableLevel.unit:
-      return "Unidad";
-    case PivotTableLevel.year:
-      return "Año";
-  }
-}
-
 class PivotTableSection extends StatefulWidget {
   String report;
   PivotTable pivotTable;
@@ -478,10 +463,11 @@ class _PivotTableSectionState extends State<PivotTableSection> {
       menuContent: TabbedMenu(
         editTabBuilder: (_) {
           return PivotEditPane(
+            report: widget.report,
+            pivotTable: widget.pivotTable.identifier,
+            setPivotTable: widget.updatePivotTable,
             nameController: nameController,
             filters: widget.pivotTable.filters,
-            onFileRemoved: _onFileRemoved,
-            onFileAdded: _onFileAdded,
             onOptionAdded: _onOptionAdded,
             onOptionRemoved: _onOptionRemoved,
             onOptionSwitched: _onOptionSwitched,

--- a/python-app/lib/pivot_table/recalculate.py
+++ b/python-app/lib/pivot_table/recalculate.py
@@ -40,21 +40,17 @@ def recalculate(pivot_table: PivotTable, preloaded_data_frame: pandas.DataFrame 
     if data_frame is None:
         data_frame = import_data_frame(file_path=pivot_table.source.merged_file, key=pivot_table.identifier)
     
-    print("Hello 1")
     combinable_filters = get_combinable_filters(data_frame=data_frame, filters=pivot_table.filters)
-    print("Hello 2")
     fix_charts(filters=combinable_filters, filters_order=pivot_table.filters_order)
     pivot_table.filters = combinable_filters
 
     _ordered_filters = ordered_filters(filters_order=pivot_table.filters_order, filters=pivot_table.filters)
-    print("Hello 3")
     new_data = get_data_of_frame(
         data_frame=data_frame, 
         filters=_ordered_filters, 
         filter_function=pivot_table.filter_function, 
         aggregate_function=pivot_table.aggregate_function
         )
-    print("Hello 4")
     pivot_table.data = new_data
 
     return (new_data, combinable_filters)

--- a/python-app/routes/pivot_table/filter/__init__.py
+++ b/python-app/routes/pivot_table/filter/__init__.py
@@ -1,4 +1,5 @@
 from routes.pivot_table.filter.add_option import add_option_to_filter
+from routes.pivot_table.filter.create_filter import create_filter
 from routes.pivot_table.filter.remove_option import remove_option_from_filter
 from routes.pivot_table.filter.switch_option import switch_option_in_filter
 from routes.pivot_table.filter.delete_filter import delete_filter
@@ -9,6 +10,7 @@ from flask import Blueprint
 blueprint = Blueprint("filter", __name__, url_prefix="/filter")
 
 add_option_to_filter(blueprint)
+create_filter(blueprint)
 remove_option_from_filter(blueprint)
 switch_option_in_filter(blueprint)
 delete_filter(blueprint)

--- a/python-app/routes/pivot_table/filter/create_filter.py
+++ b/python-app/routes/pivot_table/filter/create_filter.py
@@ -1,0 +1,56 @@
+from lib.with_flask import with_flask
+from lib.get_entities_from_request import entities_for_editing_pivot_table
+from lib.get_or_panic import get_or_panic
+from lib.descriptive_error import DescriptiveError
+from lib.pivot_table.recalculate import recalculate
+from lib.pivot_table.ordered_filters import find_filter
+from lib.pivot_table.get_combinable_filters import get_combinable_filters
+from lib.data_frame.data_frame_io import import_data_frame
+
+from models.pivot_table.pivot_table_level import PivotTableLevel
+from models.pivot_table.data_filter.self import DataFilter
+from models.pivot_table.data_filter.selection_mode import SelectionMode
+from models.pivot_table.data_filter.charting_mode import ChartingMode
+
+from flask import request
+
+import pandas
+
+@with_flask("/create", methods=["POST"])
+def create_filter():
+    report, pivot_table = entities_for_editing_pivot_table(request=request)
+
+    level: PivotTableLevel = get_or_panic(request.json, 'level', 'No se incluyó el nivel del nuevo filtro en la request')
+    try:
+        level = PivotTableLevel(level)
+    except:
+        raise DescriptiveError(http_error_code=400, message=f"El valor de nivel pasado no es válido. Se usó {level = }")
+    
+    if level in (filters := [ _filter.level for _filter in pivot_table.filters ]):
+        raise DescriptiveError(http_error_code=400, message=f"El filtro solicitado ya existe en la tabla dinámica. {filters = }")
+    
+    raw_filter = DataFilter(
+        level=level,
+        selected_values=[],
+        possible_values=[],
+        # This has to match the default mode in the fronted
+        # to improve UI consistency
+        selection_mode=SelectionMode.MANY,
+        charting_mode=ChartingMode.NONE
+        )
+    
+    pivot_table.filters.append(raw_filter)
+    pivot_table.filters_order.append(level)
+
+    data_frame = import_data_frame(file_path=pivot_table.source.merged_file, key=pivot_table.identifier)
+    refined_filters = get_combinable_filters(data_frame=data_frame, filters=pivot_table.filters)
+    # Given the fact that I created a new, empty filter, there is no need to fix charts nor to
+    # recalculate data
+
+    refined_filter = find_filter(level=level, filters=refined_filters)
+
+    pivot_table.filters = refined_filters
+    pivot_table.last_edit = pandas.Timestamp.now()
+    report.save()
+    
+    return refined_filter.to_dict(), 200


### PR DESCRIPTION
Añadí las funcionalidades para crear filtros y añadir archivos de datos a un pivot table; sin embargo, hace falta probarlas.
Entre otras cosas, mis actividades incluyen lo siguiente:
- Crear la ruta `filter/create`
- Implementar la API para `filter/create` en el frontend
- Crear componente para añadir nuevos filtros (aka, FilterSelector)
- Enlacé el FilterSelector con el backend usando la API del frontend
- Corregí un bug en la ruta `filter/create` que generaba filtros inicialmente inválidos siempre
- Añadí un botón en `PivotMetadataPane` para añadir nuevos archivos a un PivotTable